### PR TITLE
Add local hyper params and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ cd src/win-arena-container/client
 python show_results.py --result_dir <path_to_results_folder>
 ```
 
+The table below provides a comparison of various non-proprietary techniques and their hyperparameters used by the Navi agent in our study:
+
+| Hyperparameter     | Possible Values                    | Description                                                                                      | Recommended `a11y_backend` Value                   |
+|---------------|------------------------------------|--------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| `som_origin`  | `oss`, `a11y`, `mixed-oss`          | Determines how the Set-of-Mark (SoM) is achieved.                                                | `win32` for `oss`; `uia` for `a11y`, `mixed-oss`   |
+|               | `mixed`, `mixed-oss`  | If set to any "mixed" option, the agent partially relies on the accessibility tree for SoM entities. | `uia` (more reliable but slower)                   |
+|               | `oss`                               | Uses webparse, groundingdino, and OCR (TesseractOCR) pipelines.                                   | `win32` (faster performance)                       |
+|               | `a11y`                              | Relies on accessibility tree extraction for SoM.                                                 | `uia` (more reliable but slower)                   |
+| `a11y_backend`| `win32`, `uia`                      | Dictates how the accessibility tree should be extracted.                                          | `win32` for `oss`; `uia` for `a11y` and mixed types|
+|               | `win32`                             | Faster but less reliable accessibility tree extraction.                                           | Use with `oss` or non-"mixed" types.               |
+|               | `uia`                               | Slower but more reliable accessibility tree extraction.                                           | Use with `a11y`, `mixed`, `mixed-oss` |
+
 #### 4.2 Local development tips
 
 At first sight it might seem challenging to develop/debug code running inside the docker container. However, we provide a few tips to make this process easier. Check the [Development-Tips Doc](./docs/Development-Tips.md) for more details such as:

--- a/src/win-arena-container/start_client.sh
+++ b/src/win-arena-container/start_client.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 agent="navi"
+model="gpt-4-vision-preview"
+som_origin="oss"
+a11y_backend="uia"
 clean_results=true
 worker_id="0"
 num_workers="1"
@@ -12,6 +15,18 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --agent)
             agent=$2
+            shift 2
+            ;;
+        --model)
+            model=$2
+            shift 2
+            ;;
+        --som-origin)
+            som_origin=$2
+            shift 2
+            ;;
+        --a11y-backend)
+            a11y_backend=$2
             shift 2
             ;;
         --clean-results)
@@ -37,12 +52,15 @@ while [[ $# -gt 0 ]]; do
         --help)
             echo "Usage: $0 [options]"
             echo "Options:"
-            echo "  --agent <agent>          The agent to use (default: navi)"
-            echo "  --clean-results <bool>   Clean the results directory before running the client (default: true)"
-            echo "  --worker-id <id>         The worker ID"
-            echo "  --num-workers <num>      The number of workers"
-            echo "  --result-dir <dir>       The directory to store the results (default: ./results)"
-            echo "  --json-name <name>       The name of the JSON file to use (default: test_all.json)"
+            echo "  --agent <agent>                 The agent to use (default: navi)"
+            echo "  --model <model>                 The model to use (default: gpt-4-vision-preview, available options are: gpt-4o-mini, gpt-4-vision-preview, gpt-4o, gpt-4-1106-vision-preview)"
+            echo "  --som-origin <som_origin>       The SoM (Set-of-Mark) origin to use (default: oss, available options are: oss, a11y, mixed-oss)"
+            echo "  --a11y-backend <a11y_backend>   The a11y accessibility backend to use (default: uia, available options are: uia, win32)"
+            echo "  --clean-results <bool>          Clean the results directory before running the client (default: true)"
+            echo "  --worker-id <id>                The worker ID"
+            echo "  --num-workers <num>             The number of workers"
+            echo "  --result-dir <dir>              The directory to store the results (default: ./results)"
+            echo "  --json-name <name>              The name of the JSON file to use (default: test_all.json)"
             exit 0
             ;;
         *)
@@ -56,4 +74,4 @@ if [ "$clean_results" = true ]; then
 fi
 
 echo "Running agent $agent..."
-python run.py --agent "$agent" --worker_id "$worker_id" --num_workers "$num_workers" --result_dir "$result_dir" --test_all_meta_path "$json_name"
+python run.py --agent "$agent" --model "$model" --som_origin "$som_origin" --a11y_backend "$a11y_backend" --worker_id "$worker_id" --num_workers "$num_workers" --result_dir "$result_dir" --test_all_meta_path "$json_name"


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `start_client.sh` script to enhance the configurability and documentation of the win-arena-container client. The most important changes include adding a comparison table of hyperparameters to the `README.md` and introducing new command-line options to the `start_client.sh` script.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R171-R182): Added a table comparing various non-proprietary techniques and their hyperparameters used by the Navi agent, including descriptions and recommended values for `a11y_backend`.

Script enhancements:

* [`start_client.sh`](diffhunk://#diff-b30dd58452a1a6c34e35d70544212ac81103e82f7c32bf2febe748e33c9bb647R4-R6): Introduced new variables (`model`, `som_origin`, `a11y_backend`) with default values.
* [`start_client.sh`](diffhunk://#diff-b30dd58452a1a6c34e35d70544212ac81103e82f7c32bf2febe748e33c9bb647R20-R31): Added new command-line options (`--model`, `--som-origin`, `--a11y-backend`) to allow users to specify these parameters when running the script.
* [`start_client.sh`](diffhunk://#diff-b30dd58452a1a6c34e35d70544212ac81103e82f7c32bf2febe748e33c9bb647R56-R58): Updated the usage message to include descriptions for the new command-line options.
* [`start_client.sh`](diffhunk://#diff-b30dd58452a1a6c34e35d70544212ac81103e82f7c32bf2febe748e33c9bb647L59-R77): Modified the script to pass the new parameters (`model`, `som_origin`, `a11y_backend`) to the `python run.py` command.