### PR TITLE
Fix hyperparams table and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ cd src/win-arena-container/client
 python show_results.py --result_dir <path_to_results_folder>
 ```
 
-The table below provides a comparison of various non-proprietary techniques and their hyperparameters used by the Navi agent in our study:
+The table below provides a comparison of various combinations of hyperparameters used by the Navi agent in our study, which can be overridden by specifying `--som-origin <som_origin> --a11y-backend <a11y_backend>` when running the `run-local.sh` script:
 
 | Hyperparameter     | Possible Values                    | Description                                                                                      | Recommended Complementary Value                   |
 |---------------|------------------------------------|--------------------------------------------------------------------------------------------------|-----------------------------------------------------|


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file in the `src/win-arena-container/client` directory. The change updates the description of the hyperparameters table to include information on how to override hyperparameters when running the `run-local.sh` script.

* [`src/win-arena-container/client/README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L171-R171): Updated the description of the hyperparameters table to include instructions for overriding hyperparameters using `--som-origin` and `--a11y-backend` options.