### PR TITLE
Expose RAM_SIZE, CPU_CORES and KVM

### DIFF
--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -11,6 +11,7 @@ prepare_image=false
 skip_build=true
 interactive=false
 connect=false
+use_kvm=true
 mount_vm_storage=true
 mount_client=true
 mount_server=true
@@ -45,6 +46,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --connect)
             connect=$2
+            shift 2
+            ;;
+        --use-kvm)
+            use_kvm=$2
             shift 2
             ;;
         --mount-vm-storage)
@@ -103,6 +108,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --skip-build <true/false> : Skip building the arena container image (default: true)"
             echo "  --interactive <true/false> : Launches the arena container in interactive mode, providing access to the command line (bin/bash) without initiating the client or VM server processes. (default: false)"
             echo "  --connect <true/false> : Whether to attach to an existing arena container, only if the container exists (default: false)"
+            echo "  --use-kvm <true/false> : Whether to use KVM for VM acceleration (default: true)"
             echo "  --mount-vm-storage <true/false> : Mount the VM storage directory (default: true)"
             echo "  --mount-client <true/false> : Mount the client directory (default: true)"
             echo "  --mount-server <true/false> : Mount the server directory. Applies only for --mode dev. (default: true)"
@@ -143,4 +149,4 @@ if [[ -z "$OPENAI_API_KEY" && (-z "$AZURE_API_KEY" || -z "$AZURE_ENDPOINT") ]]; 
     log_error_exit "Either OPENAI_API_KEY must be set or both AZURE_API_KEY and AZURE_ENDPOINT must be set: $1"
 fi
 
-./run.sh --mode $mode --prepare-image $prepare_image --container-name $container_name --skip-build $skip_build --interactive $interactive --connect $connect --mount-vm-storage $mount_vm_storage --mount-client $mount_client --mount-server $mount_server --browser-port $browser_port --rdp-port $rdp_port --start-client $start_client --agent $agent --model $model --som-origin $som_origin --a11y-backend $a11y_backend --gpu-enabled $gpu_enabled --openai-api-key $OPENAI_API_KEY --azure-api-key $AZURE_API_KEY --azure-endpoint $AZURE_ENDPOINT
+./run.sh --mode $mode --prepare-image $prepare_image --container-name $container_name --skip-build $skip_build --interactive $interactive --connect $connect --use-kvm $use_kvm --mount-vm-storage $mount_vm_storage --mount-client $mount_client --mount-server $mount_server --browser-port $browser_port --rdp-port $rdp_port --start-client $start_client --agent $agent --model $model --som-origin $som_origin --a11y-backend $a11y_backend --gpu-enabled $gpu_enabled --openai-api-key $OPENAI_API_KEY --azure-api-key $AZURE_API_KEY --azure-endpoint $AZURE_ENDPOINT

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -12,6 +12,8 @@ skip_build=true
 interactive=false
 connect=false
 use_kvm=true
+ram_size=8G
+cpu_cores=8
 mount_vm_storage=true
 mount_client=true
 mount_server=true
@@ -50,6 +52,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --use-kvm)
             use_kvm=$2
+            shift 2
+            ;;
+        --ram-size)
+            ram_size=$2
+            shift 2
+            ;;
+        --cpu-cores)
+            cpu_cores=$2
             shift 2
             ;;
         --mount-vm-storage)
@@ -109,6 +119,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --interactive <true/false> : Launches the arena container in interactive mode, providing access to the command line (bin/bash) without initiating the client or VM server processes. (default: false)"
             echo "  --connect <true/false> : Whether to attach to an existing arena container, only if the container exists (default: false)"
             echo "  --use-kvm <true/false> : Whether to use KVM for VM acceleration (default: true)"
+            echo "  --ram-size <ram_size> : RAM size for the VM (default: 8GB)"
+            echo "  --cpu-cores <cpu_cores> : Number of CPU cores for the VM (default: 8)"
             echo "  --mount-vm-storage <true/false> : Mount the VM storage directory (default: true)"
             echo "  --mount-client <true/false> : Mount the client directory (default: true)"
             echo "  --mount-server <true/false> : Mount the server directory. Applies only for --mode dev. (default: true)"
@@ -149,4 +161,4 @@ if [[ -z "$OPENAI_API_KEY" && (-z "$AZURE_API_KEY" || -z "$AZURE_ENDPOINT") ]]; 
     log_error_exit "Either OPENAI_API_KEY must be set or both AZURE_API_KEY and AZURE_ENDPOINT must be set: $1"
 fi
 
-./run.sh --mode $mode --prepare-image $prepare_image --container-name $container_name --skip-build $skip_build --interactive $interactive --connect $connect --use-kvm $use_kvm --mount-vm-storage $mount_vm_storage --mount-client $mount_client --mount-server $mount_server --browser-port $browser_port --rdp-port $rdp_port --start-client $start_client --agent $agent --model $model --som-origin $som_origin --a11y-backend $a11y_backend --gpu-enabled $gpu_enabled --openai-api-key $OPENAI_API_KEY --azure-api-key $AZURE_API_KEY --azure-endpoint $AZURE_ENDPOINT
+./run.sh --mode $mode --prepare-image $prepare_image --container-name $container_name --skip-build $skip_build --interactive $interactive --connect $connect --use-kvm $use_kvm --ram-size $ram_size --cpu-cores $cpu_cores --mount-vm-storage $mount_vm_storage --mount-client $mount_client --mount-server $mount_server --browser-port $browser_port --rdp-port $rdp_port --start-client $start_client --agent $agent --model $model --som-origin $som_origin --a11y-backend $a11y_backend --gpu-enabled $gpu_enabled --openai-api-key $OPENAI_API_KEY --azure-api-key $AZURE_API_KEY --azure-endpoint $AZURE_ENDPOINT

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -12,6 +12,8 @@ skip_build=true
 interactive=false
 connect=false
 use_kvm=true
+ram_size=8G
+cpu_cores=8
 mount_vm_storage=true
 mount_client=true
 mount_server=true
@@ -53,6 +55,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --use-kvm)
             use_kvm=$2
+            shift 2
+            ;;
+        --ram-size)
+            ram_size=$2
+            shift 2
+            ;;
+        --cpu-cores)
+            cpu_cores=$2
             shift 2
             ;;
         --mount-vm-storage)
@@ -124,6 +134,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --interactive <true/false> : Launches the arena container in interactive mode, providing access to the command line (bin/bash) without initiating the client or VM server processes. (default: false)"
             echo "  --connect <true/false> : Whether to attach to an existing arena container, only if the container exists (default: false)"
             echo "  --use-kvm <true/false> : Whether to use KVM for VM acceleration (default: true)"
+            echo "  --ram-size <ram_size> : RAM size for the VM (default: 8GB)"
+            echo "  --cpu-cores <cpu_cores> : Number of CPU cores for the VM (default: 8)"
             echo "  --mount-vm-storage <true/false> : Mount the VM storage directory (default: true)"
             echo "  --mount-client <true/false> : Mount the client directory (default: true)"
             echo "  --mount-server <true/false> : Mount the server directory. Applies only for --mode dev. (default: true)"
@@ -232,7 +244,15 @@ invoke_docker_container() {
     # Add KVM
     if [ "$use_kvm" = true ]; then
         docker_command+=" --device=/dev/kvm"
+    else
+        docker_command+=" -e KVM=N"
     fi
+
+    # Set the RAM size
+    docker_command+=" -e RAM_SIZE=$ram_size"
+
+    # Set the CPU cores
+    docker_command+=" -e CPU_CORES=$cpu_cores"
 
     # Mount the setup image
     if [ "$prepare_image" = true ]; then

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -13,17 +13,18 @@ getrealpath () (
     fi
 )
 
-# Core function to extract a JSON field value, only from the first level of the JSON structure using regex
+# Core function to extract a JSON field value, only from the first level of the JSON structure
 extract_json_field() {
     local field_name=$1
     local input=$2
-    # Use regex to extract the field value at the first JSON level
+    # Use sed to extract the field value at the first JSON level
     local result
-    result=$(echo "$input" | grep -oP '"'"$field_name"'"\s*:\s*"\K[^"]+')
-    if [[ $? -ne 0 ]]; then
+    result=$(echo "$input" | sed -n 's/.*"'"$field_name"'"[[:space:]]*:[[:space:]]*\([^,}]*\).*/\1/p' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    if [[ -z "$result" ]]; then
         echo ""
     else
-        echo "$result"
+        # Remove surrounding quotes if present
+        echo "$result" | sed 's/^"//;s/"$//'
     fi
 }
 

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -13,18 +13,17 @@ getrealpath () (
     fi
 )
 
-# Core function to extract a JSON field value, only from the first level of the JSON structure
+# Core function to extract a JSON field value, only from the first level of the JSON structure using regex
 extract_json_field() {
     local field_name=$1
     local input=$2
-    # Use sed to extract the field value at the first JSON level
+    # Use regex to extract the field value at the first JSON level
     local result
-    result=$(echo "$input" | sed -n 's/.*"'"$field_name"'"[[:space:]]*:[[:space:]]*\([^,}]*\).*/\1/p' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-    if [[ -z "$result" ]]; then
+    result=$(echo "$input" | grep -oP '"'"$field_name"'"\s*:\s*"\K[^"]+')
+    if [[ $? -ne 0 ]]; then
         echo ""
     else
-        # Remove surrounding quotes if present
-        echo "$result" | sed 's/^"//;s/"$//'
+        echo "$result"
     fi
 }
 


### PR DESCRIPTION
This pull request introduces several enhancements to the `scripts/run-local.sh` and `scripts/run.sh` scripts, focusing on adding support for KVM acceleration, configuring VM resources, and improving script documentation.

### Enhancements to VM configuration:

* Added new options for KVM acceleration, RAM size, and CPU cores to the `scripts/run-local.sh` script:
  - `use_kvm` (default: true)
  - `ram_size` (default: 8G)
  - `cpu_cores` (default: 8)

* Updated `scripts/run.sh` to support the new VM configuration options:
  - Added parameters `use_kvm`, `ram_size`, and `cpu_cores`
  - Included a check for the existence of `/dev/kvm`, and set `use_kvm` to false if not found
  - Modified `invoke_docker_container` function to handle KVM, RAM size, and CPU cores settings