### PR TITLE
Fix broken mirror and py alias

### DIFF
--- a/src/win-arena-container/vm/setup/setup.ps1
+++ b/src/win-arena-container/vm/setup/setup.ps1
@@ -53,11 +53,10 @@ if (-not $pythonExecutablePath) {
     } else {
         Write-Host "Installing Python for current user..."
         Start-Process -FilePath $pythonInstallerFilePath -Args "/quiet InstallAllUsers=0 PrependPath=0" -NoNewWindow -Wait
-        $pythonExecutablePath = Get-ChildItem -Path $userPythonPath -Filter python.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
-        
+        $pythonExecutablePath = "$userPythonPath\Python310\python.exe"
         $setAliasExpression = "Set-Alias -Name $pythonAlias -Value `"$pythonExecutablePath`""
         Add-Content -Path $PROFILE -Value $setAliasExpression
-        Invoke-Expression $setAliasExpression    
+        Invoke-Expression $setAliasExpression
     }
 }
 

--- a/src/win-arena-container/vm/setup/tools_config.json
+++ b/src/win-arena-container/vm/setup/tools_config.json
@@ -28,9 +28,9 @@
     },
     "LibreOffice": {
         "mirrors": [
-            "https://mirrors.iu13.net/tdf/libreoffice/stable/24.2.5/win/x86_64/LibreOffice_24.2.5_Win_x86-64.msi",
-            "https://download.documentfoundation.org/libreoffice/stable/24.2.5/win/x86_64/LibreOffice_24.2.5_Win_x86-64.msi",
-            "https://mirror.raiolanetworks.com/tdf/libreoffice/_testing_/24.2.5/win/x86_64/LibreOffice_24.2.5.2_Win_x86-64.msi"
+            "https://mirror.raiolanetworks.com/tdf/libreoffice/stable/24.8.2/win/x86_64/LibreOffice_24.8.2_Win_x86-64.msi",
+            "https://mirrors.iu13.net/tdf/libreoffice/stable/24.8.2/win/x86_64/LibreOffice_24.8.2_Win_x86-64.msi",
+            "https://download.documentfoundation.org/libreoffice/stable/24.8.2/win/x86_64/LibreOffice_24.8.2_Win_x86-64.msi"
         ]
     },
     "VLC": {


### PR DESCRIPTION
This pull request includes updates to the Python installation script and the LibreOffice mirror URLs in the setup configuration. The most important changes include specifying the Python executable path directly and updating the LibreOffice mirrors to the latest version.

Fixes Issue #23

### Updates to Python Installation Script:
* [`src/win-arena-container/vm/setup/setup.ps1`](diffhunk://#diff-88b9c6b4eb10ac59d9658f5ecf02a3af5ed8c753a26098d5db2082f7e8373ce8L56-R56): Modified the script to directly set the Python executable path to `"$userPythonPath\Python310\python.exe"` instead of searching for it recursively.

### Updates to LibreOffice Mirrors:
* [`src/win-arena-container/vm/setup/tools_config.json`](diffhunk://#diff-864e5a079869e365c0d18c045f619173405d184653381f1453c2aee825a11599L31-R33): Updated the LibreOffice mirror URLs to version `24.8.2` from the previous `24.2.5`.