### PR TITLE
Fix broken setup caused by latest setup.iso

### DIFF
--- a/scripts/build-container-image.sh
+++ b/scripts/build-container-image.sh
@@ -23,7 +23,7 @@ while [[ $# -gt 0 ]]; do
             echo "Usage: $0 [options]"
             echo "Options:"
             echo "  --mode <dev/azure> : Mode (default: azure)"
-            echo "  --build-base-image <true/false> : Whether to build also the winarena-base image (default: false)"
+            echo "  --build-base-image <true/false> : Whether to build the winarena-base image (default: false)"
             exit 0
             ;;
         *)

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -8,7 +8,7 @@ source ./shared.sh
 # Default parameters
 mode="azure" # Default to azure if no argument is provided
 prepare_image=false
-skip_build=true
+skip_build=false
 interactive=false
 connect=false
 use_kvm=true
@@ -115,7 +115,7 @@ while [[ $# -gt 0 ]]; do
             echo "Options:"
             echo "  --container-name <name> : Name of the arena container (default: winarena)"
             echo "  --prepare-image <true/false> : Prepare an arena golden image (default: false)"
-            echo "  --skip-build <true/false> : Skip building the arena container image (default: true)"
+            echo "  --skip-build <true/false> : Skip building the arena container image (default: false)"
             echo "  --interactive <true/false> : Launches the arena container in interactive mode, providing access to the command line (bin/bash) without initiating the client or VM server processes. (default: false)"
             echo "  --connect <true/false> : Whether to attach to an existing arena container, only if the container exists (default: false)"
             echo "  --use-kvm <true/false> : Whether to use KVM for VM acceleration (default: true)"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -8,7 +8,7 @@ source ./shared.sh
 # Default parameters
 mode="azure" # Default to azure if no argument is provided
 prepare_image=false
-skip_build=true
+skip_build=false
 interactive=false
 connect=false
 use_kvm=true
@@ -130,7 +130,7 @@ while [[ $# -gt 0 ]]; do
             echo "Options:"
             echo "  --container-name <name> : Name of the arena container (default: winarena)"
             echo "  --prepare-image <true/false> : Prepare an arena golden image (default: false)"
-            echo "  --skip-build <true/false> : Skip building the arena container image (default: true)"
+            echo "  --skip-build <true/false> : Skip building the arena container image (default: false)"
             echo "  --interactive <true/false> : Launches the arena container in interactive mode, providing access to the command line (bin/bash) without initiating the client or VM server processes. (default: false)"
             echo "  --connect <true/false> : Whether to attach to an existing arena container, only if the container exists (default: false)"
             echo "  --use-kvm <true/false> : Whether to use KVM for VM acceleration (default: true)"

--- a/src/win-arena-container/Dockerfile-WinArena-Base
+++ b/src/win-arena-container/Dockerfile-WinArena-Base
@@ -40,7 +40,6 @@ COPY src/win-arena-container/client/requirements.txt /client/requirements.txt
 RUN pip install --no-cache-dir -r /client/requirements.txt && \
     pip install --no-cache-dir requests easyocr tenacity onnxruntime pyOpenSSL sentencepiece anytree
 
-
 # Download model weights
 RUN mkdir -p /models/groundingDINO/ && \
     wget -q https://github.com/IDEA-Research/GroundingDINO/releases/download/v0.1.0-alpha/groundingdino_swint_ogc.pth -O /models/groundingDINO/groundingdino_swint_ogc.pth && \

--- a/src/win-arena-container/vm/unattend-files/azure_win11x64-enterprise-eval.xml
+++ b/src/win-arena-container/vm/unattend-files/azure_win11x64-enterprise-eval.xml
@@ -80,7 +80,6 @@
         <AcceptEula>true</AcceptEula>
         <FullName>Docker</FullName>
         <Organization>Windows for Docker</Organization>
-        <ProductKey />
       </UserData>
       <EnableFirewall>false</EnableFirewall>
       <Diagnostics>
@@ -104,49 +103,6 @@
           <Path>reg.exe add "HKLM\SYSTEM\Setup\MoSetup" /v AllowUpgradesWithUnsupportedTPMOrCPU /t REG_DWORD /d 1 /f</Path>
         </RunSynchronousCommand>
       </RunSynchronous>
-    </component>
-    <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-      <DriverPaths>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="1">
-          <Path>D:\viostor\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="2">
-          <Path>D:\NetKVM\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="3">
-          <Path>D:\Balloon\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="4">
-          <Path>D:\pvpanic\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="5">
-          <Path>D:\qemupciserial\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="6">
-          <Path>D:\qxldod\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="7">
-          <Path>D:\vioinput\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="8">
-          <Path>D:\viorng\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="9">
-          <Path>D:\vioscsi\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="10">
-          <Path>D:\vioserial\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="11">
-          <Path>D:\viogpudo\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="12">
-          <Path>D:\sriov\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="13">
-          <Path>D:\viofs\w11\amd64</Path>
-        </PathAndCredentials>
-      </DriverPaths>
     </component>
   </settings>
   <settings pass="offlineServicing">
@@ -303,6 +259,11 @@
           <Order>24</Order>
           <Path>reg.exe add "HKLM\Software\Policies\Microsoft\Windows\CloudContent" /v "DisableConsumerAccountStateContent" /t REG_DWORD /d 1 /f</Path>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>25</Order>
+          <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
+          <Description>Set Network Location to Home</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
@@ -315,8 +276,8 @@
       <FirewallGroups>
         <FirewallGroup wcm:action="add" wcm:keyValue="RemoteDesktop">
           <Active>true</Active>
-          <Group>Remote Desktop</Group>
           <Profile>all</Profile>
+          <Group>@FirewallAPI.dll,-28752</Group>
         </FirewallGroup>
       </FirewallGroups>
     </component>
@@ -382,133 +343,123 @@
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
           <Order>2</Order>
+          <CommandLine>reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters" /v "RequireSecuritySignature" /t REG_DWORD /d 0 /f</CommandLine>
+          <Description>Disable SMB signing requirement</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>3</Order>
           <CommandLine>reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\Lsa" /v LimitBlankPasswordUse /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Allow RDP login with blank password</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>3</Order>
+          <Order>4</Order>
           <CommandLine>reg.exe add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\PasswordLess\Device" /v "DevicePasswordLessBuildVersion" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Enable option for passwordless sign-in</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>4</Order>
+          <Order>5</Order>
           <CommandLine>cmd /C wmic useraccount where name="Docker" set PasswordExpires=false</CommandLine>
           <Description>Password Never Expires</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>5</Order>
+          <Order>6</Order>
           <CommandLine>cmd /C POWERCFG -H OFF</CommandLine>
           <Description>Disable Hibernation</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>6</Order>
+          <Order>7</Order>
           <CommandLine>cmd /C POWERCFG -X -monitor-timeout-ac 0</CommandLine>
           <Description>Disable monitor blanking</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>7</Order>
-          <CommandLine>reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" /f</CommandLine>
-          <Description>Disable Network Discovery popup</Description>
-        </SynchronousCommand>
-        <SynchronousCommand wcm:action="add">
           <Order>8</Order>
-          <CommandLine>reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\Network\NetworkLocationWizard" /v "HideWizard" /t REG_DWORD /d 1 /f</CommandLine>
-          <Description>Disable Network Discovery popup</Description>
-        </SynchronousCommand>
-        <SynchronousCommand wcm:action="add">
-          <Order>9</Order>
           <CommandLine>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Edge" /v "HideFirstRunExperience" /t REG_DWORD /d 1 /f</CommandLine>
           <Description>Disable first-run experience in Edge</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>10</Order>
+          <Order>9</Order>
           <CommandLine>reg.exe add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "HideFileExt" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Show file extensions in Explorer</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>11</Order>
+          <Order>10</Order>
           <CommandLine>reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\Power" /v "HibernateFileSizePercent" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Zero Hibernation File</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>12</Order>
+          <Order>11</Order>
           <CommandLine>reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\Power" /v "HibernateEnabled" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Disable Hibernation</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>13</Order>
+          <Order>12</Order>
           <CommandLine>cmd /C POWERCFG -X -standby-timeout-ac 0</CommandLine>
           <Description>Disable Sleep</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>14</Order>
+          <Order>13</Order>
           <CommandLine>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" /v "fAllowUnlistedRemotePrograms" /t REG_DWORD /d 1 /f</CommandLine>
           <Description>Enable RemoteAPP to launch unlisted programs</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>15</Order>
-          <CommandLine>reg.exe add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Cortana" /v "IsAvailable" /t REG_DWORD /d 0 /f</CommandLine>
-          <Description>Disable Cortana</Description>
-        </SynchronousCommand>
-        <SynchronousCommand wcm:action="add">
-          <Order>16</Order>
+          <Order>14</Order>
           <CommandLine>reg.exe add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "ShowTaskViewButton" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Remove Task View from the Taskbar</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>17</Order>
+          <Order>15</Order>
           <CommandLine>reg.exe add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "TaskbarDa" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Remove Widgets from the Taskbar</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>18</Order>
+          <Order>16</Order>
           <CommandLine>reg.exe add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "TaskbarMn" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Remove Chat from the Taskbar</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>19</Order>
+          <Order>17</Order>
           <CommandLine>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "NoAutoUpdate" /t REG_DWORD /d 1 /f</CommandLine>
           <Description>Turn off Windows Update auto download</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>20</Order>
-          <CommandLine>netsh advfirewall firewall set rule group="Network Discovery" new enable=Yes</CommandLine>
+          <Order>18</Order>
+          <CommandLine>netsh advfirewall firewall set rule group="@FirewallAPI.dll,-32752" new enable=Yes</CommandLine>
           <Description>Enable Network Discovery</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>21</Order>
-          <CommandLine>netsh advfirewall firewall set rule group="File and Printer Sharing" new enable=Yes</CommandLine>
+          <Order>19</Order>
+          <CommandLine>netsh advfirewall firewall set rule group="@FirewallAPI.dll,-28502" new enable=Yes</CommandLine>
           <Description>Enable File Sharing</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>22</Order>
+          <Order>20</Order>
           <CommandLine>reg.exe add "HKCU\Control Panel\UnsupportedHardwareNotificationCache" /v SV1 /d 0 /t REG_DWORD /f</CommandLine>
           <Description>Disable unsupported hardware notifications</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>23</Order>
+          <Order>21</Order>
           <CommandLine>reg.exe add "HKCU\Control Panel\UnsupportedHardwareNotificationCache" /v SV2 /d 0 /t REG_DWORD /f</CommandLine>
           <Description>Disable unsupported hardware notifications</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
+          <Order>22</Order>
+          <CommandLine>pnputil -i -a C:\Windows\Drivers\viogpudo\viogpudo.inf</CommandLine>
+          <Description>Install VirtIO display driver</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>23</Order>
+          <CommandLine>cmd /C rd /q C:\Windows.old</CommandLine>
+          <Description>Remove empty Windows.old folder</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
           <Order>24</Order>
-          <CommandLine>reg.exe add "HKCU\Software\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell" /v ExecutionPolicy /d Unrestricted /t REG_SZ /f</CommandLine>
-          <Description>Set PowerShell execution policy to Unrestricted for current user</Description>
+          <CommandLine>cmd /C if exist "C:\oem\install.bat" start "Install" "cmd /C C:\oem\install.bat"</CommandLine>
+          <Description>Execute custom script from the OEM folder if exists</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
           <Order>25</Order>
-          <CommandLine>cmd /C attrib -R "C:\oem\*.*" /S /D >> "C:\oem\unattend_log.txt" 2>&1 && start "Install" "cmd /C C:\oem\install.bat >> C:\oem\unattend_log.txt 2>&1"</CommandLine>
-          <Description>Remove the read-only attribute from all files and subdirectories in the oem folder, and execute the install.bat script</Description>
-        </SynchronousCommand>
-         <SynchronousCommand wcm:action="add">
-          <Order>26</Order>
           <CommandLine>cmd /C "echo. > C:\Users\Docker\Desktop\hello.txt"</CommandLine>
           <Description>Create an empty text file on the desktop</Description>
-        </SynchronousCommand>
-        <SynchronousCommand wcm:action="add">
-          <Order>27</Order>
-          <CommandLine>bcdedit /set {default} recoveryenabled No</CommandLine>
-          <Description>Disable automatic Windows Recovery after system crashes</Description>
         </SynchronousCommand>
       </FirstLogonCommands>
     </component>

--- a/src/win-arena-container/vm/unattend-files/dev_win11x64-enterprise-eval.xml
+++ b/src/win-arena-container/vm/unattend-files/dev_win11x64-enterprise-eval.xml
@@ -80,7 +80,6 @@
         <AcceptEula>true</AcceptEula>
         <FullName>Docker</FullName>
         <Organization>Windows for Docker</Organization>
-        <ProductKey />
       </UserData>
       <EnableFirewall>false</EnableFirewall>
       <Diagnostics>
@@ -104,49 +103,6 @@
           <Path>reg.exe add "HKLM\SYSTEM\Setup\MoSetup" /v AllowUpgradesWithUnsupportedTPMOrCPU /t REG_DWORD /d 1 /f</Path>
         </RunSynchronousCommand>
       </RunSynchronous>
-    </component>
-    <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-      <DriverPaths>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="1">
-          <Path>D:\viostor\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="2">
-          <Path>D:\NetKVM\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="3">
-          <Path>D:\Balloon\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="4">
-          <Path>D:\pvpanic\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="5">
-          <Path>D:\qemupciserial\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="6">
-          <Path>D:\qxldod\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="7">
-          <Path>D:\vioinput\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="8">
-          <Path>D:\viorng\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="9">
-          <Path>D:\vioscsi\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="10">
-          <Path>D:\vioserial\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="11">
-          <Path>D:\viogpudo\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="12">
-          <Path>D:\sriov\w11\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="13">
-          <Path>D:\viofs\w11\amd64</Path>
-        </PathAndCredentials>
-      </DriverPaths>
     </component>
   </settings>
   <settings pass="offlineServicing">
@@ -303,6 +259,11 @@
           <Order>24</Order>
           <Path>reg.exe add "HKLM\Software\Policies\Microsoft\Windows\CloudContent" /v "DisableConsumerAccountStateContent" /t REG_DWORD /d 1 /f</Path>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>25</Order>
+          <Path>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\NetworkList\Signatures\FirstNetwork" /v Category /t REG_DWORD /d 1 /f</Path>
+          <Description>Set Network Location to Home</Description>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
@@ -315,8 +276,8 @@
       <FirewallGroups>
         <FirewallGroup wcm:action="add" wcm:keyValue="RemoteDesktop">
           <Active>true</Active>
-          <Group>Remote Desktop</Group>
           <Profile>all</Profile>
+          <Group>@FirewallAPI.dll,-28752</Group>
         </FirewallGroup>
       </FirewallGroups>
     </component>
@@ -382,133 +343,123 @@
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
           <Order>2</Order>
+          <CommandLine>reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters" /v "RequireSecuritySignature" /t REG_DWORD /d 0 /f</CommandLine>
+          <Description>Disable SMB signing requirement</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>3</Order>
           <CommandLine>reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\Lsa" /v LimitBlankPasswordUse /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Allow RDP login with blank password</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>3</Order>
+          <Order>4</Order>
           <CommandLine>reg.exe add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\PasswordLess\Device" /v "DevicePasswordLessBuildVersion" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Enable option for passwordless sign-in</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>4</Order>
+          <Order>5</Order>
           <CommandLine>cmd /C wmic useraccount where name="Docker" set PasswordExpires=false</CommandLine>
           <Description>Password Never Expires</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>5</Order>
+          <Order>6</Order>
           <CommandLine>cmd /C POWERCFG -H OFF</CommandLine>
           <Description>Disable Hibernation</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>6</Order>
+          <Order>7</Order>
           <CommandLine>cmd /C POWERCFG -X -monitor-timeout-ac 0</CommandLine>
           <Description>Disable monitor blanking</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>7</Order>
-          <CommandLine>reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" /f</CommandLine>
-          <Description>Disable Network Discovery popup</Description>
-        </SynchronousCommand>
-        <SynchronousCommand wcm:action="add">
           <Order>8</Order>
-          <CommandLine>reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\Network\NetworkLocationWizard" /v "HideWizard" /t REG_DWORD /d 1 /f</CommandLine>
-          <Description>Disable Network Discovery popup</Description>
-        </SynchronousCommand>
-        <SynchronousCommand wcm:action="add">
-          <Order>9</Order>
           <CommandLine>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Edge" /v "HideFirstRunExperience" /t REG_DWORD /d 1 /f</CommandLine>
           <Description>Disable first-run experience in Edge</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>10</Order>
+          <Order>9</Order>
           <CommandLine>reg.exe add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "HideFileExt" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Show file extensions in Explorer</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>11</Order>
+          <Order>10</Order>
           <CommandLine>reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\Power" /v "HibernateFileSizePercent" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Zero Hibernation File</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>12</Order>
+          <Order>11</Order>
           <CommandLine>reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\Power" /v "HibernateEnabled" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Disable Hibernation</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>13</Order>
+          <Order>12</Order>
           <CommandLine>cmd /C POWERCFG -X -standby-timeout-ac 0</CommandLine>
           <Description>Disable Sleep</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>14</Order>
+          <Order>13</Order>
           <CommandLine>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" /v "fAllowUnlistedRemotePrograms" /t REG_DWORD /d 1 /f</CommandLine>
           <Description>Enable RemoteAPP to launch unlisted programs</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>15</Order>
-          <CommandLine>reg.exe add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Cortana" /v "IsAvailable" /t REG_DWORD /d 0 /f</CommandLine>
-          <Description>Disable Cortana</Description>
-        </SynchronousCommand>
-        <SynchronousCommand wcm:action="add">
-          <Order>16</Order>
+          <Order>14</Order>
           <CommandLine>reg.exe add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "ShowTaskViewButton" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Remove Task View from the Taskbar</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>17</Order>
+          <Order>15</Order>
           <CommandLine>reg.exe add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "TaskbarDa" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Remove Widgets from the Taskbar</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>18</Order>
+          <Order>16</Order>
           <CommandLine>reg.exe add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "TaskbarMn" /t REG_DWORD /d 0 /f</CommandLine>
           <Description>Remove Chat from the Taskbar</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>19</Order>
+          <Order>17</Order>
           <CommandLine>reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "NoAutoUpdate" /t REG_DWORD /d 1 /f</CommandLine>
           <Description>Turn off Windows Update auto download</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>20</Order>
-          <CommandLine>netsh advfirewall firewall set rule group="Network Discovery" new enable=Yes</CommandLine>
+          <Order>18</Order>
+          <CommandLine>netsh advfirewall firewall set rule group="@FirewallAPI.dll,-32752" new enable=Yes</CommandLine>
           <Description>Enable Network Discovery</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>21</Order>
-          <CommandLine>netsh advfirewall firewall set rule group="File and Printer Sharing" new enable=Yes</CommandLine>
+          <Order>19</Order>
+          <CommandLine>netsh advfirewall firewall set rule group="@FirewallAPI.dll,-28502" new enable=Yes</CommandLine>
           <Description>Enable File Sharing</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>22</Order>
+          <Order>20</Order>
           <CommandLine>reg.exe add "HKCU\Control Panel\UnsupportedHardwareNotificationCache" /v SV1 /d 0 /t REG_DWORD /f</CommandLine>
           <Description>Disable unsupported hardware notifications</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>23</Order>
+          <Order>21</Order>
           <CommandLine>reg.exe add "HKCU\Control Panel\UnsupportedHardwareNotificationCache" /v SV2 /d 0 /t REG_DWORD /f</CommandLine>
           <Description>Disable unsupported hardware notifications</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>24</Order>
-          <CommandLine>reg.exe add "HKCU\Software\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell" /v ExecutionPolicy /d Unrestricted /t REG_SZ /f</CommandLine>
-          <Description>Set PowerShell execution policy to Unrestricted for current user</Description>
+          <Order>22</Order>
+          <CommandLine>pnputil -i -a C:\Windows\Drivers\viogpudo\viogpudo.inf</CommandLine>
+          <Description>Install VirtIO display driver</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>25</Order>
+          <Order>23</Order>
+          <CommandLine>cmd /C rd /q C:\Windows.old</CommandLine>
+          <Description>Remove empty Windows.old folder</Description>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>24</Order>
           <CommandLine>cmd /C if exist "\\host.lan\Data\install.bat" start "Install" "cmd /C \\host.lan\Data\install.bat"</CommandLine>
           <Description>Execute custom script from the Shared folder if exists</Description>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <Order>26</Order>
+          <Order>25</Order>
           <CommandLine>cmd /C "echo. > C:\Users\Docker\Desktop\hello.txt"</CommandLine>
           <Description>Create an empty text file on the desktop</Description>
-        </SynchronousCommand>
-        <SynchronousCommand wcm:action="add">
-          <Order>27</Order>
-          <CommandLine>bcdedit /set {default} recoveryenabled No</CommandLine>
-          <Description>Disable automatic Windows Recovery after system crashes</Description>
         </SynchronousCommand>
       </FirstLogonCommands>
     </component>


### PR DESCRIPTION
This pull request includes multiple changes to various scripts and configuration files to update default parameters, modify build options, and adjust configuration settings, that are required for compatibility with the latest Win11 eval setup.iso.

### Script Parameter Updates:
* [`scripts/build-container-image.sh`](diffhunk://#diff-c05e1cb5ce2b10aac5da7357176005b6d398e1d9646d8721830ef9397bb9a56eL26-R26): Corrected the description for the `--build-base-image` option.
* [`scripts/run-local.sh`](diffhunk://#diff-b3d62fb37fde53182ca08cab5dbea767b743368d042814617dc9704c75a637e7L11-R11): Changed the default value of `skip_build` from `true` to `false` and updated the corresponding option description.
* [`scripts/run.sh`](diffhunk://#diff-bb563bfe483a3a9b1649cf50d2246475b9565947f5226b94fa0d72c9786ab298L11-R11): Changed the default value of `skip_build` from `true` to `false` and updated the corresponding option description.

### Windows VM Configuration Updates:
* [`src/win-arena-container/vm/unattend-files/azure_win11x64-enterprise-eval.xml`](diffhunk://#diff-69c9e540edab6eb8ffa69d571c3f4e032cfa4a3f67c8376033ee06c8268dadb2L83): Removed `<ProductKey />` entry and adjusted various registry settings and synchronous commands.
* [`src/win-arena-container/vm/unattend-files/dev_win11x64-enterprise-eval.xml`](diffhunk://#diff-61ab3ebf6860921cc1266a120a77271e4edd5531b1da4d833f70ba7b1aba3ecaL83): Removed `<ProductKey />` entry and adjusted various registry settings and synchronous commands.